### PR TITLE
Using the framebuffer size in pixels

### DIFF
--- a/executable.py
+++ b/executable.py
@@ -94,10 +94,12 @@ def main():
     hdr_program.setInt('sceneMap', 0)
     hdr_program.setInt('bloomMap', 1)
 
+    window_width_px, window_height_px = glfw.get_framebuffer_size(window)
+
     hdrbuffer = HDRBuffer()
-    hdrbuffer.create(window_width, window_height)
+    hdrbuffer.create(window_width_px, window_height_px)
     blurbuffer = BlurBuffer()
-    blurbuffer.create(window_width, window_height)
+    blurbuffer.create(window_width_px, window_height_px)
 
     bloom = Bloom(hdrbuffer, hdr_program, blurbuffer, blur_program)
 
@@ -144,7 +146,9 @@ def main():
             cam.draw_multiple(depth_program)
 
         hdrbuffer.bind()
-        glViewport(0, 0, window_width, window_height)
+
+        window_width_px, window_height_px = glfw.get_framebuffer_size(window)
+        glViewport(0, 0, window_width_px, window_height_px)
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
 
         draw_objs(square, program, perspective, light_pos, texture_grid, normal_grid, specular_grid, depth_grid)
@@ -168,10 +172,11 @@ def resize_callback(window, w, h):
         global window_width, window_height, hdrbuffer, blurbuffer
         window_width, window_height = w, h
         glm.perspective(45, window_width / window_height, config['near_plane'], config['far_plane'])
+        window_width_px, window_height_px = glfw.get_framebuffer_size(window)
         hdrbuffer.delete()
-        hdrbuffer.create(window_width, window_height)
+        hdrbuffer.create(window_width_px, window_height_px)
         blurbuffer.delete()
-        blurbuffer.create(window_width, window_height)
+        blurbuffer.create(window_width_px, window_height_px)
 
 
 def key_callback(window, key, scancode, action, mods):


### PR DESCRIPTION
Using the framebuffer size in pixels in glViewport and during the creation of HDRBuffer and BlurBuffer
This change solves the following bug on MacOS:
<img width="1430" alt="Screenshot 2023-02-24 at 19 08 20" src="https://user-images.githubusercontent.com/19516094/221256608-998a3d95-4e39-413b-87c8-f9550c2d7f87.png">
